### PR TITLE
Possible fix for crashes

### DIFF
--- a/client/clientui.py
+++ b/client/clientui.py
@@ -41,7 +41,8 @@ class ClientUI(tk.Frame):
         # pprint(vars(master))
         self.side_bar = master.children['side_bar']
         self.output_panel = master.children['output_frame'].children['output']
-        # self.output_panel = self.output_frame.children['output']
+        self.output_panel.configure(state="normal")
+        self.output_panel.bind('<Key>',lambda e: 'break')
         self.input = master.children['input']
 
         self.char_width = Font(self.output_panel, self.output_panel.cget("font")).measure('0')
@@ -151,10 +152,7 @@ class ClientUI(tk.Frame):
                 pprint(skoot)
 
     def draw_output(self, text, tags=None):
-        self.output_panel.configure(state="normal")
-        # scroll_position = self.output_panel.scrollbar.get()
         self.output_panel.insert(tk.END, text, tags)
-        self.output_panel.configure(state="disabled")
         self.scroll_output()
 
         # If we're logging the session, we need to handle that


### PR DESCRIPTION
Potential fix for #53  and maybe #24, found via http://stackoverflow.com/questions/2914603/segmentation-fault-while-redirecting-sys-stdout-to-tkinter-text-widget

In a comment on this solution, "Nash: Instead of ignoring keypresses, an alternative is to remove "Text" from the bindtags for the widget. –"

Give this a try and see if it fixes the random crashes for you? Seems to do so on ubuntu for me.
