### PR TITLE
Cleanup login

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -81,8 +81,6 @@ class Client:
                 buffer = str(self.socket.recv(4096), encoding='utf8')
             except Exception as exc:
                 pass
-                # pprint(exc.args)
-                # pprint("SOMETHING BAD HAPPENED")
             buffer = buffer.splitlines()
             if not buffer.__len__() == 0:
                 for number, line in enumerate(buffer):
@@ -97,8 +95,10 @@ class Client:
                             self.send("SECRET " + secret)
                             self.send("HASH " + zealous_hash)
                             self.send("CHAR ")
+                            # After a Zealotry login the server still sends a password prompt. This just responds to
+                            # that with a dummy entry.
+                            self.send("Nope")
             else:
-                # pprint(buffer)
                 break
         if self.connect:
             self.shutdown()

--- a/client/clientui.py
+++ b/client/clientui.py
@@ -4,7 +4,6 @@ import re
 from collections import deque
 import html.parser
 from math import floor
-from pprint import pprint
 
 from preferences.preferences import Preferences
 
@@ -38,10 +37,8 @@ class ClientUI(tk.Frame):
         self.status = dict()
         self.create_widgets()
 
-        # pprint(vars(master))
         self.side_bar = master.children['side_bar']
         self.output_panel = master.children['output_frame'].children['output']
-        # self.output_panel = self.output_frame.children['output']
         self.input = master.children['input']
 
         self.char_width = Font(self.output_panel, self.output_panel.cget("font")).measure('0')
@@ -64,7 +61,6 @@ class ClientUI(tk.Frame):
             # Before we nuke the HTML closing tags, decide if we need to un-nest some lists.
             if self.list_depth > 0:
                 self.list_depth -= line.count('</ul>')
-                # pprint('List depth now lowered to: ' + str(self.list_depth))
             line = re.sub(r"</.*?>", "", line)
             tags = []
             self.draw_output("\n")
@@ -72,7 +68,6 @@ class ClientUI(tk.Frame):
             # line is now a string with HTML opening tags.
             # Each tag should delineate segment of the string so that if removed the resulting string
             # would be the output line.
-
             # It can be a subset of (antiquated) HTML tags:
             # center, font, hr, ul, li, pre, b
             pattern = re.compile(r'<(.*?)>')
@@ -84,6 +79,8 @@ class ClientUI(tk.Frame):
                     if re.search(r'thinks aloud:', segment):
                         # Just a thought, print it!
                         self.draw_output('<' + segment + '>', tuple(tags))
+                    elif re.search(r'xch_page', segment):
+                        pass  # @todo Actually clear the output buffer?
                     elif re.match(r'font', segment):
                         # Handle font changes
                         # So far I know of size and color attributes.
@@ -121,7 +118,10 @@ class ClientUI(tk.Frame):
                         # Not a special segment
                         self.draw_output(segment, tuple(tags))
             else:
-                self.draw_output(line, None)
+                # We're always going to see this with a Zealotry login. The users don't need to know that
+                # though so just suppress it.
+                if line.find('Either that user does not exist or has a different password.') < 0:
+                    self.draw_output(line, None)
 
     def draw_tabs(self):
         tabs = ""
@@ -147,8 +147,6 @@ class ClientUI(tk.Frame):
                 exit_update = skoot_search.group(2).split(',')
                 exit_elements = [exit_update[x:x + 4] for x in range(0, len(exit_update), 4)]
                 self.update_exits(exit_elements)
-            else:
-                pprint(skoot)
 
     def draw_output(self, text, tags=None):
         self.output_panel.configure(state="normal")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ base = None
 
 setup(
     name="TEC Client",
-    version="0.5.2-alpha",
+    version="0.5.3-alpha",
     description="TEC Client in Python",
     options={
         "build_exe": build_exe_options


### PR DESCRIPTION
Fixes #40 

This filters out the `<xch_page clear="text">` line and takes care of the first input being ignored and informing the use their character does not exist.
